### PR TITLE
Implement hash router 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "style-loader": "^3.3.4",
+        "ts-loader": "^9.5.1",
+        "typescript": "^5.4.5",
         "webpack": "^5.90.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^4.15.1"
@@ -8969,6 +8971,68 @@
         "node": ">=12"
       }
     },
+    "node_modules/ts-loader": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
+      "integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.0.0",
+        "micromatch": "^4.0.0",
+        "semver": "^7.3.4",
+        "source-map": "^0.7.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/ts-loader/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-loader/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-loader/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ts-loader/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -9007,6 +9071,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vanillajs-to-typescript",
   "version": "1.0.0",
   "description": "Vanilla javascript SPA",
-  "main": "./src/index.js",
+  "main": "./src/index.ts",
   "type": "module",
   "scripts": {
     "start": "webpack-dev-server --mode development --config ./webpack.config.js",
@@ -13,6 +13,8 @@
   "license": "ISC",
   "devDependencies": {
     "@babel/core": "^7.23.9",
+    "@babel/plugin-transform-modules-commonjs": "^7.23.3",
+    "@babel/plugin-transform-runtime": "^7.23.9",
     "@babel/preset-env": "^7.23.9",
     "@testing-library/dom": "^9.3.4",
     "babel-loader": "^9.1.3",
@@ -21,12 +23,12 @@
     "html-webpack-plugin": "^5.6.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "style-loader": "^3.3.4",
+    "ts-loader": "^9.5.1",
+    "typescript": "^5.4.5",
     "webpack": "^5.90.0",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^4.15.1",
-    "@babel/plugin-transform-modules-commonjs": "^7.23.3",
-    "@babel/plugin-transform-runtime": "^7.23.9",
-    "jest-environment-jsdom": "^29.7.0"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -9,11 +9,8 @@
     </head>
     <body style="margin:0px">
         <header>
-            <!-- <button data-navigate="/">home</button>
-            <button data-navigate="/melon">melon</button> -->
-            <a href="#/">home</a>
-            <a href="#/melon">melon</a>
-
+            <button data-navigate="/">home</button>
+            <button data-navigate="/melon">melon</button>
         </header>
         <main class="app"></main>
         <script>

--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,8 @@
     <body style="margin:0px">
         <header>
             <button data-navigate="/">home</button>
-            <button data-navigate="/melon">melon</button>
+            <button data-navigate="/spotify">spotify</button>
+            <button data-navigate="/spotify/brahms/symphony4">detail</button>
         </header>
         <main class="app"></main>
         <script>

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,13 @@
         <title>Toss Vanilla SPA</title>
     </head>
     <body style="margin:0px">
+        <header>
+            <!-- <button data-navigate="/">home</button>
+            <button data-navigate="/melon">melon</button> -->
+            <a href="#/">home</a>
+            <a href="#/melon">melon</a>
+
+        </header>
         <main class="app"></main>
         <script>
             

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,0 @@
-Document.querySelector();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,21 @@
 import createRouter from "./router";
+import { urlParamsType } from "./router";
 
 const container: HTMLElement = document.querySelector("main") as HTMLElement;
 const pages = {
   home: () => (container.innerText = "home page"),
-  melon: () => (container.innerText = "melon page"),
+  spotify: () => (container.innerText = "spotify page"),
+  board: (params?: urlParamsType) =>
+    (container.innerText = `${params?.name} ${params?.song}`),
 };
 
 const router = createRouter();
 
-router.addRoute("#/", pages.home).addRoute("#/melon", pages.melon).start();
+router
+  .addRoute("#/", pages.home)
+  .addRoute("#/spotify", pages.spotify)
+  .addRoute("#/spotify/:name/:song", pages.board)
+  .start();
 
 window.addEventListener("click", (event: MouseEvent) => {
   const target = event.target as HTMLElement;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,9 @@ const router = createRouter();
 
 router.addRoute("#/", pages.home).addRoute("#/melon", pages.melon).start();
 
-// window.addEventListener("click", (event: MouseEvent) => {
-//   const target = event.target as HTMLElement;
-//   console.log(target);
-//   if (target.matches("[data-navigate]")) {
-//     router.navigate(target.dataset.navigate as string);
-//   }
-// });
+window.addEventListener("click", (event: MouseEvent) => {
+  const target = event.target as HTMLElement;
+  if (target.matches("[data-navigate]")) {
+    router.navigate(target.dataset.navigate as string);
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,19 @@
+import createRouter from "./router";
+
+const container: HTMLElement = document.querySelector("main") as HTMLElement;
+const pages = {
+  home: () => (container.innerText = "home page"),
+  melon: () => (container.innerText = "melon page"),
+};
+
+const router = createRouter();
+
+router.addRoute("#/", pages.home).addRoute("#/melon", pages.melon).start();
+
+// window.addEventListener("click", (event: MouseEvent) => {
+//   const target = event.target as HTMLElement;
+//   console.log(target);
+//   if (target.matches("[data-navigate]")) {
+//     router.navigate(target.dataset.navigate as string);
+//   }
+// });

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,29 @@
+type routePair = { fragment: string; component: () => string };
+
+export default function createRouter() {
+  const routes: routePair[] = [];
+
+  const router = {
+    addRoute(fragment: string, component: () => string) {
+      routes.push({ fragment, component });
+      return this;
+    },
+
+    start() {
+      const checkRoutes = () => {
+        const currentRoute = routes.find(
+          (route) => route.fragment === window.location.hash
+        ) as routePair;
+        currentRoute.component();
+      };
+
+      window.addEventListener("hashchange", checkRoutes);
+      checkRoutes();
+    },
+    // navigate(fragment: string) {
+    //   window.location.hash = fragment;
+    // },
+  };
+
+  return router;
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -20,9 +20,9 @@ export default function createRouter() {
       window.addEventListener("hashchange", checkRoutes);
       checkRoutes();
     },
-    // navigate(fragment: string) {
-    //   window.location.hash = fragment;
-    // },
+    navigate(fragment: string) {
+      window.location.hash = fragment;
+    },
   };
 
   return router;

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,20 +1,60 @@
-type routePair = { fragment: string; component: () => string };
+const ROUTE_PARAMETER_REGEXP = /:(\w+)/g;
+const URL_REGEXP = "([^\\/]+)";
+
+type routeType = {
+  fragmentRegExp: RegExp;
+  component: componentType;
+  params: string[];
+};
+
+type componentType = ((params?: urlParamsType) => string) | (() => string);
+
+export type urlParamsType = Record<string, string>;
 
 export default function createRouter() {
-  const routes: routePair[] = [];
+  const routes: routeType[] = [];
 
   const router = {
-    addRoute(fragment: string, component: () => string) {
-      routes.push({ fragment, component });
+    addRoute(fragment: string, component: componentType) {
+      const params: string[] = [];
+      const parsedFragment = fragment
+        .replace(ROUTE_PARAMETER_REGEXP, (_, paramName) => {
+          params.push(paramName);
+          return URL_REGEXP;
+        })
+        .replace(/\//g, "\\/");
+
+      routes.push({
+        fragmentRegExp: new RegExp(`^${parsedFragment}$`),
+        component,
+        params,
+      });
       return this;
     },
 
     start() {
+      const getUrlParams = (route: routeType, hash: string): urlParamsType => {
+        const params: urlParamsType = {};
+        const matches = hash.match(route.fragmentRegExp) as RegExpMatchArray;
+
+        matches.shift();
+        matches.forEach((paramValue, index) => {
+          const paramName = route.params[index];
+          params[paramName] = paramValue;
+        });
+        return params;
+      };
       const checkRoutes = () => {
-        const currentRoute = routes.find(
-          (route) => route.fragment === window.location.hash
-        ) as routePair;
-        currentRoute.component();
+        const currentRoute = routes.find((route) =>
+          route.fragmentRegExp.test(window.location.hash)
+        ) as routeType;
+
+        if (currentRoute.params.length) {
+          const urlParams = getUrlParams(currentRoute, window.location.hash);
+          currentRoute.component(urlParams);
+        } else {
+          currentRoute.component();
+        }
       };
 
       window.addEventListener("hashchange", checkRoutes);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,13 +7,14 @@ const __dirname = path.dirname(__filename);
 
 export default {
   mode: "development",
-  entry: "./src/index.js",
+  entry: "./src/index.ts",
   output: {
     filename: "index.js",
     path: path.resolve(__dirname, "dist"),
     publicPath: "/",
   },
   resolve: {
+    extensions: [".ts", ".js"],
     alias: {
       "@": path.resolve(__dirname, "src/"), // src 폴더를 '@'로 alias 설정
     },
@@ -31,6 +32,11 @@ export default {
           loader: "babel-loader",
         },
       },
+      {
+        test: /\.ts$/,
+        use: "ts-loader",
+        exclude: /node_modules/,
+      }
     ],
   },
 


### PR DESCRIPTION
## 변경된 점 
* 타입스크립트를 사용할 수 있도록 설정해주었습니다. 
* 라우터를 구현하였습니다. 
 
## 구현 방식
https://fe-developers.kakaoent.com/2022/221124-router-without-library/
위 블로그를 참조하여 구현하였습니다. 

* router.ts 파일에서 라우터를 구현하였습니다. 
* 위 파일에서 createRouter를 import하여 어플리케이션에서 라우터를 사용할 수 있습니다. 
* addRoute 메소드 : url fragment와 main element의 innerText를 변경하는 함수(component)를 전달받아, routes에 정규표현식으로 전환된 fragment, component, path parameter 이름 배열을 저장합니다. 
* start 메소드 : hash 값이 변경될 떄마다 routes에서 매칭되는 element를 찾아서 component 함수를 실행시켜 DOM innerText를 변경합니다. 
* navigate 메소드 : 버튼 클릭 이벤트가 발생했을 때, 해당 버튼의 url fragment를 window hash 값으로 설정하여 url을 변경합니다. 


## 궁금한 점
addRouter 메소드에 전달하는 두 번째 파라미터 component 타입을 어떻게 정의하는게 좋을지 궁금합니다. 
component는 함수 타입이고, 파라미터를 하나 가질 수도 있고, 갖지 않을 수도 있어서, 
componentType에서 union으로 두 가지 타입을 모두 정의하여 사용하였는데, 더 좋은 방식이 있을까요?